### PR TITLE
Add cloud inference section

### DIFF
--- a/deployment/getting-started/welcome.mdx
+++ b/deployment/getting-started/welcome.mdx
@@ -40,6 +40,11 @@ LFM models are designed for efficient deployment across a wide range of platform
   <Card title="SGLang" icon="server" href="/deployment/gpu-inference/sglang">
     Structured generation and fast serving
   </Card>
+</CardGroup>
+
+## Cloud inference
+
+<CardGroup cols={3}>
   <Card title="Modal" icon="cloud" href="/deployment/gpu-inference/modal">
     Serverless GPU deployment
   </Card>

--- a/docs.json
+++ b/docs.json
@@ -185,7 +185,13 @@
             "pages": [
               "deployment/gpu-inference/transformers",
               "deployment/gpu-inference/vllm",
-              "deployment/gpu-inference/sglang",
+              "deployment/gpu-inference/sglang"
+            ]
+          },
+          {
+            "group": "Cloud inference",
+            "icon": "cloud",
+            "pages": [
               "deployment/gpu-inference/modal",
               "deployment/gpu-inference/baseten",
               "deployment/gpu-inference/fal"


### PR DESCRIPTION
## Summary

Add a separate `Cloud inference` section in Deployment.

## Changes

- move `Modal`, `Baseten`, and `Fal` under `Cloud inference`
- keep `Transformers`, `vLLM`, and `SGLang` under `GPU Inference`
- update the deployment landing page to match the sidebar grouping

## Validation

- started local Mintlify preview
- confirmed routes did not change