### PR TITLE
Remove manual edit links

### DIFF
--- a/customization/finetuning-frameworks/trl.mdx
+++ b/customization/finetuning-frameworks/trl.mdx
@@ -395,5 +395,3 @@ trainer.train()
 ***
 
 For more end to end examples, visit the [Liquid AI Cookbook](https://github.com/Liquid4All/cookbook).
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/lfm/fine-tuning/trl.md)

--- a/deployment/gpu-inference/baseten.mdx
+++ b/deployment/gpu-inference/baseten.mdx
@@ -44,5 +44,3 @@ curl -X POST https://<model-id>.api.baseten.co/environments/production/predict \
 <Note>
   Baseten endpoints expect the `Api-Key` prefix in the `Authorization` header.
 </Note>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/lfm/inference/baseten-deployment.md)

--- a/deployment/on-device/android/android-quick-start-guide.mdx
+++ b/deployment/on-device/android/android-quick-start-guide.mdx
@@ -449,5 +449,3 @@ In this pattern:
 ## 6. Examples[​](#6-examples "Direct link to 6. Examples")
 
 See [LeapSDK-Examples](https://github.com/Liquid4All/LeapSDK-Examples) for complete example apps using LeapSDK.
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/deployment/on-device/android/android-quick-start-guide.mdx)

--- a/deployment/on-device/ios/ios-quick-start-guide.mdx
+++ b/deployment/on-device/ios/ios-quick-start-guide.mdx
@@ -328,5 +328,3 @@ conversation = current.modelRunner.createConversationFromHistory(
 * Compare on-device and cloud behaviour in [Cloud AI Comparison](/deployment/on-device/ios/cloud-ai-comparison).
 
 You now have a project that loads an on-device model, streams responses, and is ready for advanced features like structured output and tool use.
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/deployment/on-device/ios/ios-quick-start-guide.mdx)

--- a/examples/customize-models/car-maker-identification.mdx
+++ b/examples/customize-models/car-maker-identification.mdx
@@ -442,5 +442,3 @@ To improve the dataset quality you can:
 
 * Increase quality by filtering out heavily cropped, occluded, or low-quality images where the brand isn't clearly identifiable
 * Increase diversity by doing data augmentation on the least represented classes.
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/customize-models/car-maker-identification.mdx)

--- a/examples/customize-models/satellite-vlm.mdx
+++ b/examples/customize-models/satellite-vlm.mdx
@@ -135,5 +135,3 @@ Use this fine-tuning pipeline as your baseline and push it further with real sat
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/customize-models/satellite-vlm.mdx)

--- a/examples/laptop-examples/audio-car-cockpit.mdx
+++ b/examples/laptop-examples/audio-car-cockpit.mdx
@@ -71,5 +71,3 @@ All running locally in real-time.
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/audio-car-cockpit.mdx)

--- a/examples/laptop-examples/audio-to-text-in-real-time.mdx
+++ b/examples/laptop-examples/audio-to-text-in-real-time.mdx
@@ -131,5 +131,3 @@ For example, we can use
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/invoice-extractor-tool-with-liquid-nanos.mdx)

--- a/examples/laptop-examples/browser-control.mdx
+++ b/examples/laptop-examples/browser-control.mdx
@@ -187,5 +187,3 @@ make run config=lfm2_350m_lora.yaml
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/browser-control.mdx)

--- a/examples/laptop-examples/flight-search-assistant.mdx
+++ b/examples/laptop-examples/flight-search-assistant.mdx
@@ -76,5 +76,3 @@ The roadmap includes:
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/flight-search-assistant.mdx)

--- a/examples/laptop-examples/invoice-extractor-tool-with-liquid-nanos.mdx
+++ b/examples/laptop-examples/invoice-extractor-tool-with-liquid-nanos.mdx
@@ -177,5 +177,3 @@ In those cases, you can fine-tune the model on your own dataset to improve accur
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/invoice-extractor-tool-with-liquid-nanos.mdx)

--- a/examples/laptop-examples/meeting-summarization.mdx
+++ b/examples/laptop-examples/meeting-summarization.mdx
@@ -121,5 +121,3 @@ for chunk in stream:
 </Card>
 
 </CardGroup>
-
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/examples/laptop-examples/meeting-summarization.mdx)

--- a/leap/edge-sdk/overview.mdx
+++ b/leap/edge-sdk/overview.mdx
@@ -36,4 +36,3 @@ The current list of main features includes:
 
 We are consistently adding to this list - see our [changelog](/leap/changelog) for detailed updates.
 
-[Edit this page](https://github.com/Liquid4All/docs/tree/main/deployment/on-device/ios/ios-quick-start-guide.mdx)

--- a/style.css
+++ b/style.css
@@ -66,15 +66,18 @@ a[href*="discord.gg"]:hover img {
 }
 
 /* Fix GitHub icon visibility in light mode for standalone Cards (not in card-groups) */
-/* Target all Card icons including github icons in example pages */
-:root:not(.dark) [class*="card"] svg:not([class*="arrow"]),
-:root:not(.dark) a[class*="block"][class*="border"] svg:not([class*="arrow"]) {
+/* Scoped to .mdx-content so the page-footer "Suggest edits" / "Raise issue" toolbar
+   buttons don't match. Their <a> has `dark:bg-codeblock/50` (substring "block") and
+   `border-standard` (substring "border"), which would otherwise satisfy
+   a[class*="block"][class*="border"] and turn their icons into purple squares. */
+:root:not(.dark) .mdx-content [class*="card"] svg:not([class*="arrow"]),
+:root:not(.dark) .mdx-content a[class*="block"][class*="border"] svg:not([class*="arrow"]) {
   background-color: #864bc4 !important;
 }
 
 /* For mask-image based icons, also set the color property as fallback */
-:root:not(.dark) [class*="card"] [style*="mask-image"],
-:root:not(.dark) a[class*="block"][class*="border"] [style*="mask-image"] {
+:root:not(.dark) .mdx-content [class*="card"] [style*="mask-image"],
+:root:not(.dark) .mdx-content a[class*="block"][class*="border"] [style*="mask-image"] {
   background-color: #864bc4 !important;
   color: #864bc4 !important;
 }

--- a/styles.js
+++ b/styles.js
@@ -88,15 +88,18 @@
     }
 
     /* Fix GitHub icon visibility in light mode for standalone Cards (not in card-groups) */
-    /* Target all Card icons including github icons in example pages */
-    :root:not(.dark) [class*="card"] svg:not([class*="arrow"]),
-    :root:not(.dark) a[class*="block"][class*="border"] svg:not([class*="arrow"]) {
+    /* Scoped to .mdx-content so the page-footer "Suggest edits" / "Raise issue" toolbar
+       buttons don't match. Their <a> has `dark:bg-codeblock/50` (substring "block") and
+       `border-standard` (substring "border"), which would otherwise satisfy
+       a[class*="block"][class*="border"] and turn their icons into purple squares. */
+    :root:not(.dark) .mdx-content [class*="card"] svg:not([class*="arrow"]),
+    :root:not(.dark) .mdx-content a[class*="block"][class*="border"] svg:not([class*="arrow"]) {
       background-color: #864bc4 !important;
     }
 
     /* For mask-image based icons, also set the color property as fallback */
-    :root:not(.dark) [class*="card"] [style*="mask-image"],
-    :root:not(.dark) a[class*="block"][class*="border"] [style*="mask-image"] {
+    :root:not(.dark) .mdx-content [class*="card"] [style*="mask-image"],
+    :root:not(.dark) .mdx-content a[class*="block"][class*="border"] [style*="mask-image"] {
       background-color: #864bc4 !important;
       color: #864bc4 !important;
     }


### PR DESCRIPTION
Some doc pages have manual "Edit this page" links. However, this link is already auto added by Mintlify. Some of these manual links are pointing to the wrong page. Removing them solves both issues: redundancy and correctness.

This PR also fixes the page buttons at the bottom whose has a theme color background and hard to see:

**Before**

<img width="785" height="88" alt="Screenshot 2026-04-26 at 20 30 37" src="https://github.com/user-attachments/assets/37be412a-dcbe-4a40-9708-900c5da1a123" />

**After**

<img width="790" height="73" alt="Screenshot 2026-04-26 at 20 31 45" src="https://github.com/user-attachments/assets/51d0fc68-0aa4-4f04-80bd-4da2043ace20" />

Resolve #91.
