### PR TITLE
chore: refresh link-snapshot.yaml after #97

### DIFF
--- a/link-snapshot.yaml
+++ b/link-snapshot.yaml
@@ -58,6 +58,7 @@ active:
   - /deployment/on-device/sdk/messages-content
   - /deployment/on-device/sdk/model-loading
   - /deployment/on-device/sdk/openai-client
+  - /deployment/on-device/sdk/overview
   - /deployment/on-device/sdk/quick-start
   - /deployment/on-device/sdk/utilities
   - /deployment/on-device/sdk/voice-assistant


### PR DESCRIPTION
## Summary

Adds `/deployment/on-device/sdk/overview` to `link-snapshot.yaml`'s `active:` list.

## Why

PR #97 introduced `deployment/on-device/sdk/overview.mdx` but the link snapshot wasn't regenerated before merge, so `snapshot:check` is failing on main (run [26214732117](https://github.com/Liquid4All/docs/actions/runs/26214732117/job/77134086884)).

The `leap/edge-sdk/overview` URL deleted by #97 stays resolvable via the existing `docs.json` redirect to the new page, so no `deleted:` entry is needed.

## Test plan

- [x] `npx tsx scripts/generateLinkSnapshot.ts --check` passes locally (`Snapshot OK: 162 active URLs verified.`)