### PR TITLE
Add LFM2.5-8B-A1B model page (DOC-63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Every inference example must use the correct sampling params from the upstream H
 |---|---|---|---|---|---|
 | LFM2.5-1.2B-Instruct | 0.1 | 50 | — | — | 1.05 |
 | LFM2.5-1.2B-Thinking | 0.1 | 50 | 0.1 | — | 1.05 |
+| LFM2.5-8B-A1B | 0.1 | 50 | — | — | 1.05 |
 | LFM2-24B-A2B | 0.1 | 50 | — | — | 1.05 |
 | LFM2 text + LFM2.5-JP | 0.3 | — | — | 0.15 | 1.05 |
 | All VL models | 0.1 | — | — | 0.15 | 1.05 |

--- a/MODEL-MATRIX.md
+++ b/MODEL-MATRIX.md
@@ -7,7 +7,7 @@
 
 | Category | Snippet files | Used by |
 |----------|--------------|---------|
-| Standard text | `snippets/quickstart/text-transformers.mdx`, `text-vllm.mdx`, `text-llamacpp.mdx` | LFM2.5-1.2B-Instruct, Thinking, JP, 350M; LFM2-8B-A1B, 2.6B, 2.6B-Exp, 1.2B, 700M, 350M |
+| Standard text | `snippets/quickstart/text-transformers.mdx`, `text-vllm.mdx`, `text-llamacpp.mdx` | LFM2.5-8B-A1B, 1.2B-Instruct, Thinking, JP, 350M; LFM2-8B-A1B, 2.6B, 2.6B-Exp, 1.2B, 700M, 350M |
 | Vision | `snippets/quickstart/vl-transformers.mdx`, `vl-vllm.mdx`, `vl-llamacpp.mdx` | LFM2.5-VL-1.6B; LFM2-VL-3B, VL-1.6B, VL-450M |
 | Audio | Inline (unique code) | LFM2.5-Audio-1.5B, LFM2-Audio-1.5B |
 | ColBERT | Inline (PyLate) | LFM2-ColBERT-350M |
@@ -22,6 +22,7 @@
 | 1.2B-Thinking | `LiquidAI/LFM2.5-1.2B-Thinking` | Standard | Standard | Standard | Standard | Yes | Yes | |
 | 1.2B-Base | `LiquidAI/LFM2.5-1.2B-Base` | Base (no chat) | -- | Base (no chat) | -- | -- | Yes | Raw text completion |
 | 1.2B-JP | `LiquidAI/LFM2.5-1.2B-JP` | Standard | Standard | Standard | Standard | Yes | Yes | Japanese |
+| 8B-A1B | `LiquidAI/LFM2.5-8B-A1B` | Standard | Standard | Standard | Standard | Yes | Yes | MoE, 128K ctx |
 | 350M | `LiquidAI/LFM2.5-350M` | Standard | Standard | Standard | Standard | Yes | Yes | Smallest LFM2.5 |
 | **LFM2.5 Vision & Audio** |
 | VL-1.6B | `LiquidAI/LFM2.5-VL-1.6B` | VL (v5 req) | VL (--image) | VL (custom wheel) | NO (PR#14069) | Yes | Yes | |

--- a/lfm/help/faqs.mdx
+++ b/lfm/help/faqs.mdx
@@ -10,7 +10,7 @@ LFM (Liquid Foundation Models) are a family of efficient language models built o
 </Accordion>
 
 <Accordion title="What context length do LFM models support?">
-All LFM models support a 32k token text context length for extended conversations and document processing.
+Most LFM models support a 32K token context length for extended conversations and document processing. The [LFM2.5-8B-A1B](/lfm/models/lfm25-8b-a1b) supports a 128K token context length.
 </Accordion>
 
 <Accordion title="Which inference frameworks are supported?">
@@ -31,7 +31,7 @@ LFM models are compatible with:
 - **Audio/speech**: LFM2.5-Audio-1.5B
 - **Extraction tasks**: LFM2-1.2B-Extract or LFM2-350M-Extract
 - **Edge deployment**: LFM2-350M or LFM2-700M for smallest footprint
-- **Highest performance**: LFM2-8B-A1B (MoE architecture)
+- **Highest performance**: LFM2.5-8B-A1B (MoE architecture, 128K context)
 </Accordion>
 
 <Accordion title="What is the difference between LFM2 and LFM2.5?">

--- a/lfm/models/complete-library.mdx
+++ b/lfm/models/complete-library.mdx
@@ -7,7 +7,7 @@ description: "Liquid Foundation Models (LFMs) are a new class of multimodal arch
 
 All of our models share the following capabilities:
 
-- 32k token context length for extended conversations and document processing
+- 32K token context length for extended conversations and document processing (128K for LFM2.5-8B-A1B)
 - Designed for fast inference with [Transformers](/deployment/gpu-inference/transformers), [llama.cpp](/deployment/on-device/llama-cpp), [vLLM](/deployment/gpu-inference/vllm), [MLX](/deployment/on-device/mlx), [Ollama](/deployment/on-device/ollama), and [LEAP](/deployment/on-device/sdk/quick-start)
 - Trainable via SFT, DPO, and GRPO with [TRL](/lfm/fine-tuning/trl) and [Unsloth](/lfm/fine-tuning/unsloth)
 
@@ -64,6 +64,7 @@ Quantization reduces model size and speeds up inference with minimal quality los
 | [LFM2.5-1.2B-Base](/lfm/models/lfm25-1.2b-base) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base-GGUF) | ✗ | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base-ONNX) | Yes (TRL) |
 | [LFM2.5-1.2B-JP](/lfm/models/lfm25-1.2b-jp) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-GGUF) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-MLX-8bit) | [✓](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-ONNX) | Yes (TRL) |
 | [LFM2.5-350M](/lfm/models/lfm25-350m) | [✓](https://huggingface.co/LiquidAI/LFM2.5-350M) | [✓](https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF) | [✓](https://huggingface.co/LiquidAI/LFM2.5-350M-MLX-8bit) | [✓](https://huggingface.co/LiquidAI/LFM2.5-350M-ONNX) | Yes (TRL) |
+| [LFM2.5-8B-A1B](/lfm/models/lfm25-8b-a1b) | [✓](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B) | [✓](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF) | [✓](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit) | [✓](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-ONNX) | Yes (TRL) |
 | LFM2 Models | | | | | |
 | [LFM2-8B-A1B](/lfm/models/lfm2-8b-a1b) | [✓](https://huggingface.co/LiquidAI/LFM2-8B-A1B) | [✓](https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF) | [✓](https://huggingface.co/mlx-community/LFM2-8B-A1B-8bit) | [✓](https://huggingface.co/onnx-community/LFM2-8B-A1B-ONNX) | Yes (TRL) |
 | [LFM2-2.6B](/lfm/models/lfm2-2.6b) | [✓](https://huggingface.co/LiquidAI/LFM2-2.6B) | [✓](https://huggingface.co/LiquidAI/LFM2-2.6B-GGUF) | [✓](https://huggingface.co/mlx-community/LFM2-2.6B-8bit) | [✓](https://huggingface.co/onnx-community/LFM2-2.6B-ONNX) | Yes (TRL) |

--- a/lfm/models/lfm25-8b-a1b.mdx
+++ b/lfm/models/lfm25-8b-a1b.mdx
@@ -1,0 +1,63 @@
+---
+title: "LFM2.5-8B-A1B"
+description: "8B parameter Mixture-of-Experts model with 1.5B active parameters for fast, reliable tool calling and 128K context"
+---
+
+import { TextTransformers } from "/snippets/quickstart/text-transformers.mdx";
+import { TextVllm } from "/snippets/quickstart/text-vllm.mdx";
+import { TextSglang } from "/snippets/quickstart/text-sglang.mdx";
+import { TextLlamacpp } from "/snippets/quickstart/text-llamacpp.mdx";
+
+<a href="/lfm/models/text-models" className="back-button">← Back to Text Models</a>
+
+LFM2.5-8B-A1B is Liquid AI's on-device personal assistant. Designed to power real-life applications, chaining tool calls, and following complex instructions on modest devices. Built on the LFM2.5 MoE architecture with 8B total parameters and only 1.5B active per forward pass, it delivers compressed performance—competitive with much bigger models on instruction following and agentic tasks—while supporting a 128K token context window.
+
+<div style={{display: 'flex', gap: '0.5rem', margin: '0.5rem 0 1.5rem 0'}}>
+  <a href="https://huggingface.co/LiquidAI/LFM2.5-8B-A1B" style={{padding: '0.35rem 0.7rem', borderRadius: '4px', fontSize: '0.85rem', fontWeight: 600, textDecoration: 'none', backgroundColor: '#fbbf24'}}><span style={{color: '#000'}}>HF</span></a>
+  <a href="https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF" style={{padding: '0.35rem 0.7rem', borderRadius: '4px', fontSize: '0.85rem', fontWeight: 600, textDecoration: 'none', backgroundColor: '#60a5fa'}}><span style={{color: '#000'}}>GGUF</span></a>
+  <a href="https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit" style={{padding: '0.35rem 0.7rem', borderRadius: '4px', fontSize: '0.85rem', fontWeight: 600, textDecoration: 'none', backgroundColor: '#c4b5fd'}}><span style={{color: '#000'}}>MLX</span></a>
+  <a href="https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-ONNX" style={{padding: '0.35rem 0.7rem', borderRadius: '4px', fontSize: '0.85rem', fontWeight: 600, textDecoration: 'none', backgroundColor: '#86efac'}}><span style={{color: '#000'}}>ONNX</span></a>
+</div>
+
+## Specifications
+
+| Property | Value |
+|----------|-------|
+| Parameters | 8B (1.5B active) |
+| Context Length | 128K tokens |
+| Architecture | LFM2.5 (MoE) |
+
+<div className="use-cases">
+<CardGroup cols={3}>
+
+<Card title="128K Context" icon="text-width">
+  Extended context window for long documents and conversations
+</Card>
+
+<Card title="MoE Efficiency" icon="microchip">
+  8B quality, 1.5B inference cost
+</Card>
+
+<Card title="Tool Calling" icon="wrench">
+  Native function calling for agentic workflows
+</Card>
+
+</CardGroup>
+</div>
+
+## Quick Start
+
+<Tabs>
+  <Tab title="Transformers">
+    <TextTransformers modelId="LiquidAI/LFM2.5-8B-A1B" samplingParams="do_sample=True, temperature=0.1, top_k=50, repetition_penalty=1.05, "></TextTransformers>
+  </Tab>
+  <Tab title="llama.cpp">
+    <TextLlamacpp ggufRepo="LiquidAI/LFM2.5-8B-A1B-GGUF" samplingFlags="--temp 0.1 --top-k 50 --repeat-penalty 1.05"></TextLlamacpp>
+  </Tab>
+  <Tab title="vLLM">
+    <TextVllm modelId="LiquidAI/LFM2.5-8B-A1B" samplingParams="temperature=0.1, top_k=50, repetition_penalty=1.05, "></TextVllm>
+  </Tab>
+  <Tab title="SGLang">
+    <TextSglang modelId="LiquidAI/LFM2.5-8B-A1B" toolCallParser="lfm2"></TextSglang>
+  </Tab>
+</Tabs>

--- a/lfm/models/lfm25-8b-a1b.mdx
+++ b/lfm/models/lfm25-8b-a1b.mdx
@@ -10,7 +10,7 @@ import { TextLlamacpp } from "/snippets/quickstart/text-llamacpp.mdx";
 
 <a href="/lfm/models/text-models" className="back-button">← Back to Text Models</a>
 
-LFM2.5-8B-A1B is Liquid AI's on-device personal assistant. Designed to power real-life applications, chaining tool calls, and following complex instructions on modest devices. Built on the LFM2.5 MoE architecture with 8B total parameters and only 1.5B active per forward pass, it delivers compressed performance—competitive with much bigger models on instruction following and agentic tasks—while supporting a 128K token context window.
+LFM2.5-8B-A1B is Liquid AI's Mixture-of-Experts model, combining 8B total parameters with only 1.5B active parameters per forward pass with a 128K context window and chain of thought reasoning. This model delivers exceptional performance in tool calling and agentic tasks while running on-device.
 
 <div style={{display: 'flex', gap: '0.5rem', margin: '0.5rem 0 1.5rem 0'}}>
   <a href="https://huggingface.co/LiquidAI/LFM2.5-8B-A1B" style={{padding: '0.35rem 0.7rem', borderRadius: '4px', fontSize: '0.85rem', fontWeight: 600, textDecoration: 'none', backgroundColor: '#fbbf24'}}><span style={{color: '#000'}}>HF</span></a>

--- a/lfm/models/text-models.mdx
+++ b/lfm/models/text-models.mdx
@@ -56,6 +56,12 @@ icon: "comment"
   Fine-tuned model for high-quality Japanese text generation.
 </Card>
 
+<Card title="LFM2.5-8B-A1B" href="/lfm/models/lfm25-8b-a1b">
+  8B · 1.5B active · <Badge shape="pill" color="blue">MoE</Badge> · <Badge shape="pill" color="green">128K</Badge>
+
+  On-device personal assistant with 128K context for tool calling and agentic tasks.
+</Card>
+
 <Card title="LFM2.5-350M" href="/lfm/models/lfm25-350m">
   350M · <Badge shape="pill" color="yellow">Fastest</Badge>
 

--- a/lfm/models/text-models.mdx
+++ b/lfm/models/text-models.mdx
@@ -57,9 +57,9 @@ icon: "comment"
 </Card>
 
 <Card title="LFM2.5-8B-A1B" href="/lfm/models/lfm25-8b-a1b">
-  8B · 1.5B active · <Badge shape="pill" color="blue">MoE</Badge> · <Badge shape="pill" color="green">128K</Badge>
+  8B · 1.5B active · <Badge shape="pill" color="blue">MoE</Badge>
 
-  On-device personal assistant with 128K context for tool calling and agentic tasks.
+  Mixture-of-experts reasoning model with 128K context for on-device tool calling and agentic tasks.
 </Card>
 
 <Card title="LFM2.5-350M" href="/lfm/models/lfm25-350m">

--- a/link-snapshot.yaml
+++ b/link-snapshot.yaml
@@ -159,6 +159,7 @@ active:
   - /lfm/models/lfm25-1.2b-jp
   - /lfm/models/lfm25-1.2b-thinking
   - /lfm/models/lfm25-350m
+  - /lfm/models/lfm25-8b-a1b
   - /lfm/models/lfm25-audio-1.5b
   - /lfm/models/lfm25-vl-1.6b
   - /lfm/models/lfm25-vl-450m


### PR DESCRIPTION
## Summary

Adds the new LFM2.5-8B-A1B model page and integrates it across the docs site per [DOC-63](https://linear.app/liquid-ai/issue/DOC-63/request-create-lfm25-8b-a1b-model-page).

**New file:**
- `lfm/models/lfm25-8b-a1b.mdx` — Full model card with description, specs (8B params / 1.5B active, 128K context, MoE architecture), use-case cards, and Quick Start tabs (Transformers, llama.cpp, vLLM, SGLang) using LFM2.5 sampling parameters.

**Updated files:**
- `lfm/models/text-models.mdx` — Added card in the LFM2.5 section with MoE and 128K badges.
- `lfm/models/complete-library.mdx` — Added row to the model chart; updated 32K context blurb to note the 128K exception.
- `lfm/help/faqs.mdx` — Updated context length FAQ (128K for 8B, 32K for rest) and model selection to recommend LFM2.5-8B-A1B for highest performance.
- `link-snapshot.yaml` — New URL added (via pre-commit hook).
- `CLAUDE.md` — Added sampling params row.
- `MODEL-MATRIX.md` — Added model entry and updated snippet mapping.

Badge links (HF, GGUF, MLX, ONNX) use placeholder URLs following the `LiquidAI/LFM2.5-8B-A1B-*` naming convention — will be updated once the HuggingFace repos are published.

## Review & Testing Checklist for Human
- [ ] Verify the model description and specs match the intended release messaging
- [ ] Confirm badge links will resolve once HuggingFace repos are created (currently placeholders following naming convention)
- [ ] Run `npx mintlify dev` and check the model page renders correctly at `/lfm/models/lfm25-8b-a1b`
- [ ] Verify sampling parameters (temp=0.1, top_k=50, rep_penalty=1.05) match the upstream HF model card when it's published

### Notes
- Sampling params follow the LFM2.5 family defaults (temp=0.1, top_k=50, repetition_penalty=1.05) per the request to "reference all existing LFM2.5 versioning". Update if the HF model card specifies different values.
- The FAQ now distinguishes 128K context for the 8B model vs 32K for all others.

Link to Devin session: https://app.devin.ai/sessions/35da4ce02f534793928b1b36fc89f5ce
Requested by: @jbuchananr