### PR TITLE
feat: add Leap SDK to Edge Inference navigation (DOC-62)

### DIFF
--- a/deployment/on-device/leap-sdk.mdx
+++ b/deployment/on-device/leap-sdk.mdx
@@ -1,0 +1,31 @@
+---
+title: "Leap SDK"
+description: "Liquid AI's official on-device inference SDK with first-class support for Liquid Foundation Models. Runs on iOS, macOS, Android, JVM desktop, Linux, and Windows."
+---
+
+<Tip>
+  Use the Leap SDK for first-class LFM support on mobile, desktop, and embedded devices — with validated defaults, multimodal inference, constrained generation, and one-call model fetching from the LEAP Model Library.
+</Tip>
+
+The **Leap SDK** is Liquid AI's official on-device inference SDK and the **only SDK with first-class support for [Liquid Foundation Models](https://www.liquid.ai/blog/liquid-foundation-models-our-first-series-of-generative-ai-models) (LFMs)**. Every published Liquid checkpoint is supported, validated, and shipped through this SDK on day-one.
+
+It's a Kotlin Multiplatform library: the same `ModelRunner` / `Conversation` / `MessageResponse` API runs on iOS, macOS, Android, JVM desktop, Linux native, Windows native, and (preview) wasmJs.
+
+## Key Features
+
+- **Day-one model coverage** — new LFM checkpoints land in the SDK release that announces them, with no manual quant conversion or template-mismatch debugging.
+- **Multimodal support** — vision (LFM2-VL) and audio (LFM2.5-Audio) use the same API as text.
+- **Constrained generation** — Kotlin annotations and Swift macros produce JSON Schemas the engine enforces at decode time.
+- **One-call model fetching** — `LeapModelDownloader.loadModel(...)` resolves, downloads, caches, and returns a ready `ModelRunner`.
+- **On-device by default** — no cloud round-trip, no per-token cost, full privacy, full offline operation.
+
+## Getting Started
+
+<CardGroup cols={2}>
+  <Card title="Full Documentation" icon="book" href="/deployment/on-device/sdk/overview">
+    SDK overview, architecture, and feature deep-dives.
+  </Card>
+  <Card title="Quick Start" icon="rocket" href="/deployment/on-device/sdk/quick-start">
+    Install via SPM or Gradle, load a model, stream a response.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -89,6 +89,7 @@
             "group": "Edge Inference",
             "icon": "mobile",
             "pages": [
+              "deployment/on-device/leap-sdk",
               "deployment/on-device/llama-cpp",
               "deployment/on-device/lm-studio",
               "deployment/on-device/mlx",

--- a/link-snapshot.yaml
+++ b/link-snapshot.yaml
@@ -42,6 +42,7 @@ active:
   - /deployment/on-device/ios/openai-client
   - /deployment/on-device/ios/utilities
   - /deployment/on-device/ios/voice-assistant
+  - /deployment/on-device/leap-sdk
   - /deployment/on-device/leap-sdk-changelog
   - /deployment/on-device/llama-cpp
   - /deployment/on-device/lm-studio


### PR DESCRIPTION
## Summary

Adds "Leap SDK" as an entry in the **Edge Inference** navigation group (LFM tab), so it appears alongside llama.cpp, LM Studio, MLX, ONNX, and Ollama.

Changes:
- **New page** `deployment/on-device/leap-sdk.mdx` — a summary page that highlights key SDK features and links to the full Leap SDK tab (overview + quick start).
- **`docs.json`** — added the new page as the first entry in the "Edge Inference" group.
- **`link-snapshot.yaml`** — auto-updated by `snapshot:update` to include the new URL.

## Review & Testing Checklist for Human
- [ ] Verify the new "Leap SDK" entry appears in the left-hand navigation under "Edge Inference" on the Mintlify preview
- [ ] Confirm the "Full Documentation" and "Quick Start" cards link correctly to the existing SDK pages

### Notes
- The Leap SDK retains its own dedicated tab with all sub-pages. This change adds a lightweight entry point in the Edge Inference section for discoverability.
- Resolves [DOC-62](https://linear.app/liquid-ai/issue/DOC-62/request-leap-sdk-does-not-show-as-an-edge-inference-option-in-left)

Link to Devin session: https://app.devin.ai/sessions/dd3b2f31a18545c39f6dedf49c80f277
Requested by: @tuliren