### PR TITLE
Add leap-finetune page to Fine-tuning section (DOC-61)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -82,7 +82,8 @@
             "pages": [
               "lfm/fine-tuning/datasets",
               "lfm/fine-tuning/trl",
-              "lfm/fine-tuning/unsloth"
+              "lfm/fine-tuning/unsloth",
+              "lfm/fine-tuning/leap-finetune"
             ]
           },
           {
@@ -273,7 +274,7 @@
     },
     {
       "source": "/customization/finetuning-frameworks/leap-finetune",
-      "destination": "/lfm/fine-tuning/trl"
+      "destination": "/lfm/fine-tuning/leap-finetune"
     },
     {
       "source": "/customization/finetuning-frameworks/datasets",

--- a/lfm/fine-tuning/leap-finetune.mdx
+++ b/lfm/fine-tuning/leap-finetune.mdx
@@ -1,0 +1,235 @@
+---
+title: "leap-finetune"
+description: "Liquid AI's open-source, config-driven CLI for fine-tuning LFM models. Supports local GPUs, Modal serverless, and SLURM clusters."
+---
+
+<Tip>
+  Use leap-finetune for a batteries-included CLI that handles SFT, DPO, and VLM fine-tuning from a single YAML config file — no boilerplate code required.
+</Tip>
+
+[leap-finetune](https://github.com/Liquid4All/leap-finetune) is Liquid AI's open-source fine-tuning tool for LFM models. Define your training job in a YAML config and run it with a single command on local GPUs, [Modal](https://modal.com) serverless infrastructure, or SLURM clusters.
+
+Different training methods require specific dataset formats. See [Datasets](/lfm/fine-tuning/datasets) for format requirements.
+
+## Installation
+
+Requires [uv](https://docs.astral.sh/uv/):
+
+```bash
+git clone https://github.com/Liquid4All/leap-finetune
+cd leap-finetune
+uv sync
+```
+
+## Quick Start
+
+Create a YAML config (or copy one from [`job_configs/`](https://github.com/Liquid4All/leap-finetune/tree/main/job_configs)):
+
+```yaml
+project_name: "my_sft_project"
+model_name: "LFM2-1.2B"
+training_type: "sft"
+
+dataset:
+  path: "HuggingFaceTB/smoltalk"
+  type: "sft"
+  limit: 1000
+  test_size: 0.2
+  subset: "all"
+
+training_config:
+  extends: "DEFAULT_SFT"
+  num_train_epochs: 3
+  per_device_train_batch_size: 2
+  learning_rate: 2e-5
+
+peft_config:
+  extends: "DEFAULT_LORA"
+  use_peft: true
+```
+
+Launch training:
+
+```bash
+uv run leap-finetune path/to/config.yaml
+```
+
+Results are saved to `outputs/{project_name}/{run_name}/`.
+
+## Training Types
+
+leap-finetune supports multiple training methods through the `training_type` field:
+
+| Training type | `training_type` | `training_config.extends` | `peft_config.extends` |
+| --- | --- | --- | --- |
+| SFT | `sft` | `DEFAULT_SFT` | `DEFAULT_LORA` |
+| DPO | `dpo` | `DEFAULT_DPO` | `DEFAULT_LORA` |
+| VLM SFT | `vlm_sft` | `DEFAULT_VLM_SFT` | `DEFAULT_VLM_LORA` |
+
+The `extends` fields inherit from base configs — any fields you specify override the defaults. Set `use_peft: false` in `peft_config` for full fine-tuning.
+
+## Compute Backends
+
+### Local GPU
+
+Training runs locally by default using Ray Train + Accelerate for distributed training:
+
+```bash
+uv run leap-finetune config.yaml
+```
+
+### Modal (Serverless GPU)
+
+Run on Modal's serverless GPUs from any machine — no local GPU required.
+
+**One-time setup:**
+
+```bash
+huggingface-cli login
+modal setup
+```
+
+Add a `modal` section to your config:
+
+```yaml
+modal:
+  gpu: "H100:4"
+  timeout: 86400
+  output_volume: "leap-finetune"
+  output_dir: "/outputs"
+  detach: false
+```
+
+Run the same way:
+
+```bash
+uv run leap-finetune config.yaml
+```
+
+Retrieve checkpoints from the Modal volume:
+
+```bash
+modal volume ls leap-finetune
+modal volume get leap-finetune <checkpoint-name> ./local-outputs
+```
+
+Set `detach: true` to submit and disconnect. Monitor with `modal app logs leap-finetune`.
+
+### SLURM
+
+Add a `slurm` section to your config to auto-generate and submit a SLURM script:
+
+```bash
+uv run leap-finetune config.yaml
+```
+
+Generate without submitting:
+
+```bash
+uv run leap-finetune slurm config.yaml
+```
+
+## Dataset Loading
+
+The `dataset.path` field accepts multiple sources:
+
+| Source | Example `path` |
+| --- | --- |
+| Local file | `/path/to/data.jsonl`, `/path/to/data.parquet` |
+| HuggingFace Hub | `HuggingFaceTB/smoltalk` |
+| S3 | `s3://bucket/path/to/data.parquet` |
+| GCS | `gs://bucket/path/to/data.parquet` |
+| Azure | `az://container/path/to/data.parquet` |
+
+Use `subset` for HuggingFace datasets with multiple configs, and `limit` to cap the number of samples.
+
+## Experiment Tracking
+
+Add `tracker` to your `training_config`:
+
+<Tabs>
+  <Tab title="Trackio">
+    [Trackio](https://huggingface.co/blog/trackio) is a free experiment tracker that logs to a HuggingFace Space.
+
+    ```yaml
+    training_config:
+      tracker: "trackio"
+      trackio_space_id: "username/my-dashboard"
+    ```
+
+    Requires a HF token (via `huggingface-cli login`). On Modal, the token is auto-injected.
+  </Tab>
+  <Tab title="Weights & Biases">
+    ```yaml
+    training_config:
+      tracker: "wandb"
+    ```
+
+    Set `WANDB_API_KEY` locally. On Modal, create a secret and reference it:
+
+    ```bash
+    modal secret create wandb-secret WANDB_API_KEY=your_key
+    ```
+
+    ```yaml
+    modal:
+      secrets:
+        - "wandb-secret"
+    ```
+  </Tab>
+</Tabs>
+
+## Evaluation Benchmarks
+
+Run benchmarks automatically during training at every `eval_steps`:
+
+```yaml
+benchmarks:
+  max_new_tokens: 128
+  benchmarks:
+    - name: "eval_set"
+      path: "/data/eval.jsonl"
+      metric: "short_answer"
+```
+
+Available metrics: `short_answer`, `grounding_iou`, `mcq_gen`, `logprob_zero_shot`.
+
+## Resuming Training
+
+Resume from the most recent checkpoint:
+
+```yaml
+training_config:
+  resume_from_checkpoint: "latest"
+```
+
+Or from a specific checkpoint:
+
+```yaml
+training_config:
+  resume_from_checkpoint: "/path/to/checkpoint-step-8000"
+```
+
+## Examples
+
+<CardGroup cols={3}>
+
+<Card title="Home Assistant" href="/examples/customize-models/home-assistant">
+  Fine-tune LFM2-350M for smart home control with leap-finetune on Modal.
+</Card>
+
+<Card title="Satellite VLM" href="/examples/customize-models/satellite-vlm">
+  Fine-tune LFM2.5-VL-450M on satellite imagery for VQA, grounding, and captioning.
+</Card>
+
+<Card title="Wildfire Prevention" href="/examples/customize-models/wildfire-prevention">
+  Fine-tune LFM2.5-VL-450M for wildfire risk assessment from aerial images.
+</Card>
+
+</CardGroup>
+
+## Resources
+
+* [leap-finetune on GitHub](https://github.com/Liquid4All/leap-finetune)
+* [Example configs](https://github.com/Liquid4All/leap-finetune/tree/main/job_configs)
+* [Liquid AI Cookbook](https://github.com/Liquid4All/cookbook)

--- a/link-snapshot.yaml
+++ b/link-snapshot.yaml
@@ -112,6 +112,7 @@ active:
   - /leap/edge-sdk/overview
   - /lfm/fine-tuning
   - /lfm/fine-tuning/datasets
+  - /lfm/fine-tuning/leap-finetune
   - /lfm/fine-tuning/trl
   - /lfm/fine-tuning/unsloth
   - /lfm/getting-started/connect-ai-tools


### PR DESCRIPTION
## Summary

Adds a dedicated documentation page for [leap-finetune](https://github.com/Liquid4All/leap-finetune) under the Fine-tuning section, so it appears alongside TRL and Unsloth as a first-class fine-tuning option.

**Changes:**
- **New page** `lfm/fine-tuning/leap-finetune.mdx` — covers installation, config-driven quick start, supported training types (SFT/DPO/VLM-SFT), compute backends (local GPU, Modal, SLURM), dataset loading, experiment tracking (Trackio/W&B), evaluation benchmarks, resume support, and links to cookbook examples.
- **Navigation** — added to the Fine-tuning group in `docs.json`.
- **Redirect fix** — updated the legacy `/customization/finetuning-frameworks/leap-finetune` redirect to point to the new page instead of `/lfm/fine-tuning/trl`.
- **Link snapshot** — added `/lfm/fine-tuning/leap-finetune` to `link-snapshot.yaml`.

## Review & Testing Checklist for Human

- [ ] Verify the page renders correctly at `/lfm/fine-tuning/leap-finetune` on the Mintlify preview
- [ ] Check that leap-finetune appears in the Fine-tuning sidebar alongside Datasets, TRL, and Unsloth
- [ ] Confirm the legacy redirect from `/customization/finetuning-frameworks/leap-finetune` resolves to the new page
- [ ] Spot-check that all external links (GitHub repo, job_configs, Modal, cookbook examples) are valid

### Notes

Resolves [DOC-61](https://linear.app/liquid-ai/issue/DOC-61/request-leap-finetune-does-not-appear-under-fine-tunning). Content sourced from the [leap-finetune README](https://github.com/Liquid4All/leap-finetune) and existing cookbook examples (home-assistant, satellite-vlm, wildfire-prevention).

Link to Devin session: https://app.devin.ai/sessions/7ce2b20117ab490abb591c0ac51cdae0
Requested by: @tuliren