### PR TITLE
[codex] Update model library starting point

### DIFF
--- a/lfm/models/complete-library.mdx
+++ b/lfm/models/complete-library.mdx
@@ -8,7 +8,7 @@ description: "Liquid Foundation Models (LFMs) are a new class of multimodal arch
 All of our models share the following capabilities:
 
 - 32K token context length for extended conversations and document processing (128K for LFM2.5-8B-A1B)
-- Designed for fast inference with [Transformers](/deployment/gpu-inference/transformers), [llama.cpp](/deployment/on-device/llama-cpp), [vLLM](/deployment/gpu-inference/vllm), [MLX](/deployment/on-device/mlx), [Ollama](/deployment/on-device/ollama), and [LEAP](/deployment/on-device/sdk/quick-start)
+- Designed for fast inference with [Transformers](/deployment/gpu-inference/transformers), [llama.cpp](/deployment/on-device/llama-cpp), [vLLM](/deployment/gpu-inference/vllm), [SGLang](/deployment/gpu-inference/sglang), [MLX](/deployment/on-device/mlx), [Ollama](/deployment/on-device/ollama), and [LEAP](/deployment/on-device/sdk/quick-start)
 - Trainable via SFT, DPO, VLM, and GRPO workflows with [LEAP Finetune](/lfm/fine-tuning/leap-finetune), [TRL](/lfm/fine-tuning/trl), and [Unsloth](/lfm/fine-tuning/unsloth)
 
 </div>
@@ -20,9 +20,9 @@ All of our models share the following capabilities:
   - [OpenRouter API](https://openrouter.ai/liquid)
 </Panel>
 
-## Model Families
+Start with the model family that matches your input and output shape, then choose a runtime based on where you want to run it. Use the complete matrix below when you need exact repository and format availability.
 
-<Note>Choose a model based on your desired functionalities. Each individual model card has specific details on deployment and customization.</Note>
+## Model Families
 
 <CardGroup cols={2}>
 
@@ -44,9 +44,31 @@ All of our models share the following capabilities:
 
 </CardGroup>
 
-## Model Formats
+## Common Workflows
 
-All LFM2 models are available in multiple formats for flexible deployment:
+<CardGroup cols={2}>
+
+<Card title="GPU Serving" icon="server" href="/deployment/gpu-inference/vllm">
+  Use [vLLM](/deployment/gpu-inference/vllm) or [SGLang](/deployment/gpu-inference/sglang) for high-throughput serving, and [Transformers](/deployment/gpu-inference/transformers) for direct Python inference.
+</Card>
+
+<Card title="Local and On-Device" icon="laptop" href="/deployment/on-device/llama-cpp">
+  Use [llama.cpp](/deployment/on-device/llama-cpp), [Ollama](/deployment/on-device/ollama), [MLX](/deployment/on-device/mlx), or the [LEAP SDK](/deployment/on-device/sdk/quick-start) depending on platform and packaging needs.
+</Card>
+
+<Card title="Fine-Tuning" icon="sliders" href="/lfm/fine-tuning/leap-finetune">
+  Start with [LEAP Finetune](/lfm/fine-tuning/leap-finetune) for managed workflows, or use [TRL](/lfm/fine-tuning/trl) and [Unsloth](/lfm/fine-tuning/unsloth) for framework-level control.
+</Card>
+
+<Card title="Model Repositories" icon="database" href="https://huggingface.co/LiquidAI/collections">
+  Browse LiquidAI collections on Hugging Face for model weights, GGUF exports, MLX packages, ONNX exports, and model cards.
+</Card>
+
+</CardGroup>
+
+## Formats
+
+Use the format that matches your runtime and deployment target:
 
 - **GGUF** — Best for local CPU/GPU inference on any platform. Use with [llama.cpp](/deployment/on-device/llama-cpp), [LM Studio](/deployment/on-device/lm-studio), or [Ollama](/deployment/on-device/ollama). Append `-GGUF` to any model name.
 - **MLX** — Best for Mac users with Apple Silicon. Leverages unified memory for fast inference via [MLX](/deployment/on-device/mlx). Browse at [mlx-community](https://huggingface.co/mlx-community/collections?search=LFM).
@@ -60,7 +82,7 @@ Quantization reduces model size and speeds up inference with minimal quality los
 - **MLX** — Available in `3bit`, `4bit`, `5bit`, `6bit`, `8bit`, and `BF16`. `8bit` is recommended.
 - **ONNX** — Supports `FP32`, `FP16`, `Q4`, and `Q8` (MoE models also support `Q4F16`). `Q4` is recommended for most deployments.
 
-## Model Chart
+## Complete Model Matrix
 
 | Model | HF | GGUF | MLX | ONNX | Trainable? |
 | ----- | -- | ---- | --- | ---- | ---------- |

--- a/style.css
+++ b/style.css
@@ -283,9 +283,9 @@ body > div.antialiased {
 
 /* Global content links - purple underline with hover effect */
 /* Scope to main content area only, exclude navigation/sidebar/tables */
-article a:not([class*="block"]):not(table a),
-[role="main"] a:not([class*="block"]):not(table a),
-.prose a:not([class*="block"]):not(table a) {
+article a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a),
+[role="main"] a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a),
+.prose a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a) {
   text-decoration: none !important;
   color: inherit !important;
   font-weight: 600 !important;
@@ -297,11 +297,24 @@ article a:not([class*="block"]):not(table a),
   transition: color 0.15s ease, background-size 0.15s ease !important;
 }
 
-article a:not([class*="block"]):not(table a):hover,
-[role="main"] a:not([class*="block"]):not(table a):hover,
-.prose a:not([class*="block"]):not(table a):hover {
+article a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a):hover,
+[role="main"] a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a):hover,
+.prose a:not([class*="block"]):not([aria-label="Navigate to header"]):not(table a):hover {
   color: #864bc4 !important;
   background-size: 100% 1.5px !important;
+}
+
+/* Heading permalink icons should not inherit prose-link underlines */
+article :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+[role="main"] :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+.prose :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+article a[href^="#"][aria-label*="link" i],
+[role="main"] a[href^="#"][aria-label*="link" i],
+.prose a[href^="#"][aria-label*="link" i] {
+  background-image: none !important;
+  background-size: 0 0 !important;
+  padding-bottom: 0 !important;
+  text-decoration: none !important;
 }
 
 /* Default table styling - applies to all tables */
@@ -708,4 +721,3 @@ table:has(thead th:nth-child(6):not(:nth-child(7))) td:first-child a:hover {
 .dark .card-group a[href^="/docs/models/"]:not([href*="text-models"]):not([href*="vision-models"]):not([href*="audio-models"]):not([href*="liquid-nanos"]):not([href*="complete-library"])::before {
   background-color: #9ca3af !important;
 }
-

--- a/styles.js
+++ b/styles.js
@@ -186,6 +186,19 @@
       color: #e5e7eb !important;
     }
 
+    /* Heading permalink icons should not inherit prose-link underlines */
+    article :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+    [role="main"] :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+    .prose :is(h1, h2, h3, h4, h5, h6) a[href^="#"],
+    article a[href^="#"][aria-label*="link" i],
+    [role="main"] a[href^="#"][aria-label*="link" i],
+    .prose a[href^="#"][aria-label*="link" i] {
+      background-image: none !important;
+      background-size: 0 0 !important;
+      padding-bottom: 0 !important;
+      text-decoration: none !important;
+    }
+
     /* Colab button sizing */
     a[href*="colab.research.google.com"] img,
     img[alt*="Colab"],


### PR DESCRIPTION
## Summary

- Add SGLang to the main model library runtime list.
- Keep the existing top panel and add a short orientation sentence for first-time readers.
- Add a compact Common Workflows section for GPU serving, local/on-device deployment, fine-tuning, and model repositories.
- Rename the lower sections to Formats and Complete Model Matrix for clearer scanning.
- Prevent heading permalink icons from inheriting the prose-link purple underline on hover.

## Impact

This makes the model library page read more naturally as a starting point while preserving the full model matrix for exact format availability. The CSS update also removes the stray purple line under generated section-link icons without changing normal prose-link styling.

## Validation

- `npm run snapshot:check`
- Snapshot OK: 170 active URLs verified.
- Checked locally with `mintlify dev` at `http://localhost:3002` and verified the `#quantization` heading permalink computes with no underline background or bottom padding.