### PR TITLE
Fix docs typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For more details on Mintlify setup and configuration, visit the [official Mintli
 
 ### Link Check
 
-The [`check-docs.yaml`](.github/workflows/check-docs.yaml) workflow has a `check-link` job that examine markdown links. Customize the config in [`link-check.json`](./link-check.json). If a link cannot be accessed (e.g. Github private repo), add the URL pattern to the `ignorePatterns` array.
+The [`check-docs.yaml`](.github/workflows/check-docs.yaml) workflow has a `check-link` job that examine markdown links. Customize the config in [`link-check.json`](./link-check.json). If a link cannot be accessed (e.g. GitHub private repo), add the URL pattern to the `ignorePatterns` array.
 
 ### Link Snapshot
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For more details on Mintlify setup and configuration, visit the [official Mintli
 
 ### Link Check
 
-The [`check-docs.yaml`](.github/workflows/check-docs.yaml) workflow has a `check-link` job that examine markdown links. Customize the config in [`link-check.json`](./link-check.json). If a link cannot be accessed (e.g. GitHub private repo), add the URL pattern to the `ignorePatterns` array.
+The [`check-docs.yaml`](.github/workflows/check-docs.yaml) workflow has a `check-link` job that examines markdown links. Customize the config in [`link-check.json`](./link-check.json). If a link cannot be accessed (e.g. GitHub private repo), add the URL pattern to the `ignorePatterns` array.
 
 ### Link Snapshot
 

--- a/lfm/key-concepts/chat-template.mdx
+++ b/lfm/key-concepts/chat-template.mdx
@@ -11,7 +11,7 @@ Conversations are formatted using special tokens:
 
 * **`<|startoftext|>`** — Start of the conversation.
 * **`<|im_start|>`** — Start of the message. Always followed by the role name (`system`, `user`, `assistant`, or `tool`) and a line break.
-* **`<|im_end|>`** — End end of the message.
+* **`<|im_end|>`** — End of the message.
 
 LFM2 supports four conversation roles:
 


### PR DESCRIPTION
## Summary
- Fix duplicated word in the chat template page.
- Correct GitHub capitalization in the README.

## Notes
Supersedes stale bot PRs #64 and #65.